### PR TITLE
Make output connection fields not required

### DIFF
--- a/summer_py/summer_model/utils/validation.py
+++ b/summer_py/summer_model/utils/validation.py
@@ -88,8 +88,8 @@ def get_model_schema(model):
                 "schema": {
                     "origin": {"type": "string"},
                     "to": {"type": "string"},
-                    "origin_condition": {"type": "string"},
-                    "to_condition": {"type": "string"},
+                    "origin_condition": {"type": "string", "required": False},
+                    "to_condition": {"type": "string", "required": False},
                 },
             },
         },


### PR DESCRIPTION
Fix issue where validation of model `output_connections` was too strict.